### PR TITLE
Add style field for easy less npm import

### DIFF
--- a/package.json
+++ b/package.json
@@ -3,6 +3,7 @@
   "version": "1.0.0",
   "description": "Vanilla JS Range Slider",
   "main": "src/scripts/index.js",
+  "style": "dist/ranger.css",
   "scripts": {
     "start": "webpack && npm run dev",
     "dev": "webpack-dev-server --devtool eval --hot --progress",


### PR DESCRIPTION
This adds the style field allowing for easy npm import via `less-plugin-npm-import`

```less
@import 'ranger'; // references node_modules/ranger/dist/style.css
```